### PR TITLE
JWT Security Refresh 토큰 기능 구현 완료.

### DIFF
--- a/server/src/main/java/com/web/MyPetForApp/auth/config/SecurityConfig.java
+++ b/server/src/main/java/com/web/MyPetForApp/auth/config/SecurityConfig.java
@@ -1,7 +1,7 @@
 package com.web.MyPetForApp.auth.config;
 
+import com.web.MyPetForApp.auth.error.ErrorhandlerFilter;
 import com.web.MyPetForApp.auth.error.JwtAccessDeniedHandler;
-import com.web.MyPetForApp.auth.error.JwtAuthenticationEntryPoint;
 import com.web.MyPetForApp.auth.filter.JwtAuthenticationFilter;
 import com.web.MyPetForApp.auth.filter.JwtAuthorizationFilter;
 import com.web.MyPetForApp.auth.provider.TokenProvider;
@@ -25,12 +25,14 @@ public class SecurityConfig {
 
     private final CorsFilter corsFilter;
 
-    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+//    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
     private final MemberRepository memberRepository;
 
     private final TokenProvider tokenProvider;
+
+    private final ErrorhandlerFilter errorhandlerFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
@@ -40,8 +42,9 @@ public class SecurityConfig {
                 .httpBasic().disable()
                 .apply(new JwtLogin())
                 .and()
+                .addFilterBefore(errorhandlerFilter, JwtAuthorizationFilter.class)
                 .exceptionHandling()
-                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+//                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                 .accessDeniedHandler(jwtAccessDeniedHandler)
                 .and()
                 .authorizeRequests()

--- a/server/src/main/java/com/web/MyPetForApp/auth/controller/AuthController.java
+++ b/server/src/main/java/com/web/MyPetForApp/auth/controller/AuthController.java
@@ -1,0 +1,23 @@
+package com.web.MyPetForApp.auth.controller;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.hibernate.internal.CoreLogging.logger;
+
+@RestController
+@RequestMapping("auth")
+public class AuthController {
+    private final Logger logger = LoggerFactory.getLogger(AuthController.class);
+
+    @GetMapping("/refresh")
+    public ResponseEntity refreshNeed() {
+        logger("refresh Token을 요청합니다.");
+        return new ResponseEntity<>("refresh token need", HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/server/src/main/java/com/web/MyPetForApp/auth/dto/AuthDetails.java
+++ b/server/src/main/java/com/web/MyPetForApp/auth/dto/AuthDetails.java
@@ -28,6 +28,8 @@ public class AuthDetails implements UserDetails {
 //        return authorities;
 //    }
 
+    public String getEmail() {return member.getEmail();}
+
     @Override
     public String getPassword() {
         return member.getPassword();
@@ -35,7 +37,7 @@ public class AuthDetails implements UserDetails {
 
     @Override
     public String getUsername() {
-        return member.getMemberName();
+        return member.getEmail();
     }
     @Override
     public boolean isAccountNonExpired() {

--- a/server/src/main/java/com/web/MyPetForApp/auth/entity/RefreshToken.java
+++ b/server/src/main/java/com/web/MyPetForApp/auth/entity/RefreshToken.java
@@ -1,0 +1,31 @@
+package com.web.MyPetForApp.auth.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@NoArgsConstructor
+@Getter
+@AllArgsConstructor
+@Builder
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column
+    private Long refreshTokenId;
+
+    private String email;
+    private String token;
+
+    public  static RefreshToken createToken(String email, String token) {
+        return RefreshToken.builder().email(email).token(token).build();
+    }
+
+    public void changeToken(String token) {
+        this.token = token;
+    }
+}

--- a/server/src/main/java/com/web/MyPetForApp/auth/error/ErrorhandlerFilter.java
+++ b/server/src/main/java/com/web/MyPetForApp/auth/error/ErrorhandlerFilter.java
@@ -1,0 +1,27 @@
+package com.web.MyPetForApp.auth.error;
+
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class ErrorhandlerFilter extends OncePerRequestFilter {
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (TokenExpiredException e) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().write("refresh token need");
+//            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "refresh token need");
+        }
+    }
+}

--- a/server/src/main/java/com/web/MyPetForApp/auth/error/JwtAuthenticationEntryPoint.java
+++ b/server/src/main/java/com/web/MyPetForApp/auth/error/JwtAuthenticationEntryPoint.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 
 @Component
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
         // 유효한 자격증명을 제공하지 않고 접근하려 할 때 401 에러 송출

--- a/server/src/main/java/com/web/MyPetForApp/auth/filter/JwtAuthorizationFilter.java
+++ b/server/src/main/java/com/web/MyPetForApp/auth/filter/JwtAuthorizationFilter.java
@@ -1,7 +1,10 @@
 package com.web.MyPetForApp.auth.filter;
 
+import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.web.MyPetForApp.auth.provider.TokenProvider;
 import com.web.MyPetForApp.member.repository.MemberRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -12,6 +15,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.time.Instant;
 
 
 public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
@@ -19,6 +23,8 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
     private MemberRepository memberRepository;
 
     private TokenProvider tokenProvider;
+
+    private final Logger logger = LoggerFactory.getLogger(JwtAuthorizationFilter.class);
 
     public JwtAuthorizationFilter(AuthenticationManager authenticationManager, MemberRepository memberRepository, TokenProvider tokenProvider) {
         super(authenticationManager);
@@ -28,23 +34,57 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
-        System.out.println("인증이나 권한 필요한 주소가 요청 되었습니다.");
+        logger.info("인증이나 권한 필요한 주소가 요청 되었습니다.");
 
-        String jwtHeader = request.getHeader("Authorization");
+        String jwtToken = resolveToken(request ,"Authorization");
 
-        if(jwtHeader == null || !jwtHeader.startsWith("Bearer")) {
-            filterChain.doFilter(request, response);
-            return;
-        }
+        if(jwtToken != null) {
+            TokenProvider.JwtCode accValidResult = tokenProvider.validateToken(jwtToken, "access");
 
-        String jwtToken = jwtHeader.replace("Bearer ", "");
-        Authentication authentication = tokenProvider.getAuthentication(jwtToken);
-
-        if(authentication != null) {
-            SecurityContextHolder.getContext().setAuthentication(authentication);
-            filterChain.doFilter(request, response);
+            if(accValidResult == TokenProvider.JwtCode.ACCESS) {
+                Authentication authentication = tokenProvider.getAuthentication(jwtToken);
+                if(authentication != null) {
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                    filterChain.doFilter(request, response);
+                }
+//        else {
+//            super.doFilterInternal(request, response, filterChain);
+            } else if (accValidResult == TokenProvider.JwtCode.EXPIRED) {
+                String refreshToken = resolveToken(request, "refresh");
+                // refresh Token이 요청헤더에 있다면
+                if(refreshToken != null) {
+                    // refresh Token을 검증
+                    TokenProvider.JwtCode refValidResult = tokenProvider.validateToken(refreshToken, "refresh");
+                    // 검증이 통과하면
+                    if(refValidResult != TokenProvider.JwtCode.DENIED) {
+                        // refresh Token 재발급
+                        String newRefreshToken = tokenProvider.updateRefreshToken(refreshToken);
+                        if(newRefreshToken != null) {
+                            response.addHeader("refresh", "Bearer " + newRefreshToken);
+                            // Access Token 재발급
+                            Authentication authentication = tokenProvider.getAuthentication(refreshToken);
+                            response.addHeader("Authorization", "Bearer " + tokenProvider.createAccessToken(authentication));
+                            SecurityContextHolder.getContext().setAuthentication(authentication);
+                            logger.info("리프레시 토큰 & 액세스 토큰 최신화 완료");
+                        }
+                    }
+                } else
+                    // refresh Token이 요청헤더에 없다면
+                    // 클라이언트에 Access Token이 만료되었음을 알리고, refresh Token을 요청헤더에 달라고 요청(예외 처리)
+                    throw new TokenExpiredException("토큰 만료", Instant.now());
+            }
         } else {
-            super.doFilterInternal(request, response, filterChain);
+            logger.info("유효한 토큰을 찾지 못하였습니다, uri : {}", request.getRequestURI());
         }
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request, String header) {
+        String jwtHeader = request.getHeader(header);
+
+        if(jwtHeader != null && jwtHeader.startsWith("Bearer")) {
+            return jwtHeader.replace("Bearer ", "");
+        }
+        return null;
     }
 }

--- a/server/src/main/java/com/web/MyPetForApp/auth/provider/TokenProvider.java
+++ b/server/src/main/java/com/web/MyPetForApp/auth/provider/TokenProvider.java
@@ -2,13 +2,13 @@ package com.web.MyPetForApp.auth.provider;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
-import com.auth0.jwt.exceptions.SignatureVerificationException;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.web.MyPetForApp.auth.dto.AuthDetails;
+import com.web.MyPetForApp.auth.entity.RefreshToken;
+import com.web.MyPetForApp.auth.repository.RefreshTokenRepository;
 import com.web.MyPetForApp.member.entity.Member;
 import com.web.MyPetForApp.member.repository.MemberRepository;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.UnsupportedJwtException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
@@ -17,28 +17,32 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.security.Key;
 import java.util.Date;
 
 @Component
 public class TokenProvider implements InitializingBean {
     private final Logger logger = LoggerFactory.getLogger(TokenProvider.class);
     private static final String AUTHORITIES_KEY = "auth";
+    private final RefreshTokenRepository refreshTokenRepository;
 
     private MemberRepository memberRepository;
 
-    public TokenProvider(MemberRepository memberRepository) {
+    public TokenProvider(MemberRepository memberRepository, RefreshTokenRepository refreshTokenRepository) {
         this.memberRepository = memberRepository;
+        this.refreshTokenRepository = refreshTokenRepository;
     }
 
     @Value("{jwt.secret}")
-    private String secret;
+    private String accessKey;
+
+    private String refreshKey = "refresh " + accessKey;
 
 //    @Value("{jwt.token-validity-in-seconds}")
 //    private int tokenValidityInMilliseconds;
 
-    private Key key;
+//    private Key key;
 
     @Override
     public void afterPropertiesSet() {
@@ -46,16 +50,17 @@ public class TokenProvider implements InitializingBean {
 //        this.key = Keys.hmacShaKeyFor(keyBytes);
     }
 
-    public String createToken(Authentication authentication) {
+    public String createAccessToken(Authentication authentication) {
 
         AuthDetails authDetails = (AuthDetails) authentication.getPrincipal();
 
         return JWT.create()
-                .withSubject("MyPet JWT token")
-                .withExpiresAt(new Date(System.currentTimeMillis() + (60 * 1000 * 60)))
+                .withSubject("MyPet JWT Access Token")
+//                .withExpiresAt(new Date(System.currentTimeMillis() + (60 * 1000 * 60)))
+                .withExpiresAt(new Date(System.currentTimeMillis() + (60 * 1000)))
                 .withClaim("id", authDetails.getMember().getMemberId())
-                .withClaim("memberName", authDetails.getUsername())
-                .sign(Algorithm.HMAC512(secret));
+                .withClaim("email", authDetails.getEmail())
+                .sign(Algorithm.HMAC512(accessKey));
 
 //        String authorities = authentication.getAuthorities().stream()
 //                .map(GrantedAuthority::getAuthority)
@@ -72,6 +77,54 @@ public class TokenProvider implements InitializingBean {
 //                .compact();
     }
 
+    private String createRefreshToken(Authentication authentication) {
+        AuthDetails authDetails = (AuthDetails) authentication.getPrincipal();
+
+        return JWT.create()
+                .withSubject("MyPet JWT Refresh Token")
+                .withExpiresAt(new Date(System.currentTimeMillis() + (60 * 1000 * 60 * 24 * 14)))
+                .withClaim("email", authDetails.getEmail())
+                .sign(Algorithm.HMAC512(refreshKey));
+    }
+    @Transactional
+    public String renewalRefreshToken(Authentication authentication) {
+        String newRefreshToken = createRefreshToken(authentication);
+        // 기존 토큰이 있다면 바꿔주고, 없다면 토큰을 만들어준다.
+        refreshTokenRepository.findByEmail(authentication.getName())
+                .ifPresentOrElse(
+                        r -> {r.changeToken(newRefreshToken);
+                        logger.info("기존 리프레시 토큰 변환");},
+                        () -> {
+                            RefreshToken toSaveToken = RefreshToken.createToken(authentication.getName(), newRefreshToken);
+                            logger.info("새로운 리프레시 토큰 저장 | member's email : {}, token : {}", toSaveToken.getEmail(), toSaveToken.getToken() );
+                            refreshTokenRepository.save(toSaveToken);
+                        }
+                );
+        return newRefreshToken;
+    }
+
+    @Transactional
+    public String updateRefreshToken(String refreshToken) throws RuntimeException {
+        // refresh Token을 DB에 저장된 토큰과 비교
+        Authentication authentication = getAuthentication(refreshToken);
+        RefreshToken findRefreshToken = refreshTokenRepository.findByEmail(authentication.getName())
+                .orElseThrow(() -> new UsernameNotFoundException("email : " + authentication.getName() + " was not found"));
+
+        // 토큰이 일치한다면
+        if(findRefreshToken.getToken().equals(refreshToken)) {
+            // 새로운 토큰 생성
+            String newRefreshToken = createRefreshToken(authentication);
+            findRefreshToken.changeToken(newRefreshToken);
+            return newRefreshToken;
+        } else {
+            logger.info("refresh Token이 일치하지 않습니다.");
+            return null;
+        }
+    }
+
+
+
+
     public Authentication getAuthentication(String token) {
 //        Claims claims = Jwts
 //                .parserBuilder()
@@ -85,11 +138,11 @@ public class TokenProvider implements InitializingBean {
 //                        .map(SimpleGrantedAuthority::new)
 //                        .collect(Collectors.toList());
 
-        String memberName = validateAndGetMemberNameToken(token);
+        String email = JWT.decode(token).getClaim("email").asString();
 
-        if(memberName != null) {
-            Member memberEntity = memberRepository.findByMemberName(memberName).orElseThrow(
-                    () -> new UsernameNotFoundException(memberName + "데이터베이스에서 찾을 수 없습니다.")
+        if(email != null) {
+            Member memberEntity = memberRepository.findByEmail(email).orElseThrow(
+                    () -> new UsernameNotFoundException(email + "데이터베이스에서 찾을 수 없습니다.")
             );
 
             AuthDetails authDetails = new AuthDetails(memberEntity);
@@ -100,7 +153,7 @@ public class TokenProvider implements InitializingBean {
         }
 
 //        Member memberEntity = Member.builder()
-//                .memberName(claims.getSubject())
+//                .email(claims.getSubject())
 //                .password("")
 //                .roles(claims.get(AUTHORITIES_KEY).toString())
 //                .build();
@@ -110,18 +163,24 @@ public class TokenProvider implements InitializingBean {
 //        return new UsernamePasswordAuthenticationToken(authDetails, token, authorities);
     }
 
-    public String  validateAndGetMemberNameToken(String token) {
+    public JwtCode validateToken(String token, String tokenType) {
+        String key = tokenType.equals("access") ? accessKey : refreshKey;
+
         try {
-            return JWT.require(Algorithm.HMAC512(secret)).build().verify(token).getClaim("memberName").asString();
-        } catch (ExpiredJwtException e) {
-            logger.info("손상된 JWT 토큰입니다.");
-        } catch (UnsupportedJwtException e) {
-            logger.info("지원하지 않는 JWT 토큰 형식입니다.");
-        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
-            logger.info("잘못된 JWT 서명입니다.");
-        } catch (SignatureVerificationException e) {
-            logger.info("JWT 토큰이 잘못되었습니다.");
+                JWT.require(Algorithm.HMAC512(key)).build().verify(token);
+            return JwtCode.ACCESS;
+        } catch (TokenExpiredException e) {
+            logger.info("만료된 토큰입니다.");
+            return JwtCode.EXPIRED;
+        } catch (JWTVerificationException e) {
+            logger.info("토큰 검증에 실패하였습니다.");
+            return JwtCode.DENIED;
         }
-        return null;
+    }
+
+    public static enum JwtCode {
+        DENIED,
+        ACCESS,
+        EXPIRED;
     }
 }

--- a/server/src/main/java/com/web/MyPetForApp/auth/repository/RefreshTokenRepository.java
+++ b/server/src/main/java/com/web/MyPetForApp/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package com.web.MyPetForApp.auth.repository;
+
+import com.web.MyPetForApp.auth.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
+    Optional<RefreshToken> findByEmail(String email);
+}

--- a/server/src/main/java/com/web/MyPetForApp/auth/service/AuthDetailsService.java
+++ b/server/src/main/java/com/web/MyPetForApp/auth/service/AuthDetailsService.java
@@ -15,9 +15,9 @@ public class AuthDetailsService implements UserDetailsService {
     private final MemberRepository memberRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String memberName) throws UsernameNotFoundException {
-        Member memberEntity = memberRepository.findByMemberName(memberName).orElseThrow(
-                () -> new UsernameNotFoundException(memberName + "데이터베이스에서 찾을 수 없습니다.")
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member memberEntity = memberRepository.findByEmail(email).orElseThrow(
+                () -> new UsernameNotFoundException(email + "데이터베이스에서 찾을 수 없습니다.")
         );
         return new AuthDetails(memberEntity);
     }

--- a/server/src/main/java/com/web/MyPetForApp/member/dto/MemberDto.java
+++ b/server/src/main/java/com/web/MyPetForApp/member/dto/MemberDto.java
@@ -5,8 +5,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Column;
-
 public class MemberDto {
 
     @Getter

--- a/server/src/main/java/com/web/MyPetForApp/member/entity/Member.java
+++ b/server/src/main/java/com/web/MyPetForApp/member/entity/Member.java
@@ -1,18 +1,15 @@
 package com.web.MyPetForApp.member.entity;
 
-import com.web.MyPetForApp.board.entity.Board;
 import com.web.MyPetForApp.cartitem.entity.CartItem;
-import com.web.MyPetForApp.comment.entity.Comment;
-import com.web.MyPetForApp.item.entity.Item;
 import com.web.MyPetForApp.order.entity.Order;
-import com.web.MyPetForApp.qna.entity.Qna;
-import com.web.MyPetForApp.review.entity.Review;
 import com.web.MyPetForApp.wish.entity.Wish;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 @Entity

--- a/server/src/main/java/com/web/MyPetForApp/member/repository/MemberRepository.java
+++ b/server/src/main/java/com/web/MyPetForApp/member/repository/MemberRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     public Optional<Member> findByMemberName(String name);
-    public Optional<Member> findByEmail(String name);
+    public Optional<Member> findByEmail(String email);
 }


### PR DESCRIPTION
* Access 토큰 만료기한 1분으로 설정되있음 (테스트 편이 사유)
* AuthController는 추후 추가 기능 대비 미리 틀만 마련해놓음
* 로그인 시 Access 토큰과 Refresh 토큰이 함께 발급됨
* Access 토큰 기한 만료시 응답 메시지에 Refresh 토큰 요청 추가
* Access 토큰 기한 만료 상태에서 Refresh 토큰을 함께 헤더에 넣어주면 -> Access 토큰 / Refresh 토큰 모두 재발급 처리