### PR TITLE
JWT Security 로그아웃 기능 구현.

### DIFF
--- a/server/src/main/java/com/web/MyPetForApp/auth/config/JwtAddLogoutHandler.java
+++ b/server/src/main/java/com/web/MyPetForApp/auth/config/JwtAddLogoutHandler.java
@@ -1,0 +1,31 @@
+package com.web.MyPetForApp.auth.config;
+
+import com.web.MyPetForApp.auth.repository.RefreshTokenRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+public class JwtAddLogoutHandler implements LogoutHandler {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    private final Logger logger = LoggerFactory.getLogger(JwtAddLogoutHandler.class);
+
+    public JwtAddLogoutHandler(RefreshTokenRepository refreshTokenRepository) {
+        this.refreshTokenRepository = refreshTokenRepository;
+    }
+
+    @Transactional
+    public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        String email = request.getParameter("email");
+        refreshTokenRepository.deleteByEmail(email);
+        logger.info("해당 유저의 refresh 토큰이 삭제되었습니다. email : {}", email);
+    }
+}

--- a/server/src/main/java/com/web/MyPetForApp/auth/config/SecurityConfig.java
+++ b/server/src/main/java/com/web/MyPetForApp/auth/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.web.MyPetForApp.auth.config;
 
 import com.web.MyPetForApp.auth.error.ErrorhandlerFilter;
 import com.web.MyPetForApp.auth.error.JwtAccessDeniedHandler;
+import com.web.MyPetForApp.auth.error.JwtAuthenticationEntryPoint;
 import com.web.MyPetForApp.auth.filter.JwtAuthenticationFilter;
 import com.web.MyPetForApp.auth.filter.JwtAuthorizationFilter;
 import com.web.MyPetForApp.auth.provider.TokenProvider;
@@ -25,7 +26,7 @@ public class SecurityConfig {
 
     private final CorsFilter corsFilter;
 
-//    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
     private final MemberRepository memberRepository;
@@ -33,6 +34,8 @@ public class SecurityConfig {
     private final TokenProvider tokenProvider;
 
     private final ErrorhandlerFilter errorhandlerFilter;
+
+    private final JwtAddLogoutHandler jwtAddLogoutHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
@@ -44,7 +47,7 @@ public class SecurityConfig {
                 .and()
                 .addFilterBefore(errorhandlerFilter, JwtAuthorizationFilter.class)
                 .exceptionHandling()
-//                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                 .accessDeniedHandler(jwtAccessDeniedHandler)
                 .and()
                 .authorizeRequests()
@@ -53,7 +56,8 @@ public class SecurityConfig {
                 .anyRequest().permitAll()
                 .and()
                 .logout()
-                .logoutSuccessUrl("/");
+                .addLogoutHandler(jwtAddLogoutHandler)
+                .logoutSuccessUrl("/api/v1/user/test");
         return httpSecurity.build();
     }
 

--- a/server/src/main/java/com/web/MyPetForApp/auth/repository/RefreshTokenRepository.java
+++ b/server/src/main/java/com/web/MyPetForApp/auth/repository/RefreshTokenRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
     Optional<RefreshToken> findByEmail(String email);
+
+    void deleteByEmail(String email);
 }


### PR DESCRIPTION
* 로그아웃 시, 해당 유저 리프레시 토큰 DB에서 삭제
* 프론트 측에서 eamil 값을 파라미터 값으로 넘겨줘야함
* 또한 프론트 측은 발급받았던 토큰을 보관중인 스토리지에서 제거